### PR TITLE
Fix build with ruby-head (2.0)

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -125,7 +125,7 @@ end
 if RUBY_PLATFORM !~ /mswin|mingw/
 
   # Check for compiler. Extract first word so ENV['CC'] can be a program name with arguments.
-  cc = (ENV["CC"] or Config::CONFIG["CC"] or "gcc").split(' ').first
+  cc = (ENV["CC"] or RbConfig::CONFIG["CC"] or "gcc").split(' ').first
   unless find_executable(cc)
     exit_failure "No C compiler found in ${ENV['PATH']}. See mkmf.log for details."
   end


### PR DESCRIPTION
Config has been deprecated for a while, and is now gone. Don't use it.
