### PR TITLE
Prevent failure when "prefix" is empty string.

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -78,7 +78,7 @@ end
 # binaries). This causes problems when /usr/lib is in the path (e.g., using
 # the default Ruby installation).
 def check_partial_imagemagick_versions()
-   prefix = config_string("prefix")
+   prefix = config_string("prefix") || ""
    matches = [
      prefix+"/lib/lib?agick*",
      prefix+"/include/ImageMagick",


### PR DESCRIPTION
In case that "prefix" is empty string, the config_string returns false. Default to empty string for that case.
