### PR TITLE
don't conflate SetImageColorspace and TransformImageColorspace

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -2986,6 +2986,35 @@ Image_colorspace(VALUE self)
  * @see Magick::colorSpace in Magick++'s Magick::colorSpace
  */
 VALUE
+Image_transform_colorspace(VALUE self, VALUE colorspace)
+{
+#if defined(HAVE_TRANSFORMIMAGECOLORSPACE)
+    Image *image;
+    ColorspaceType new_cs;
+
+    image = rm_check_frozen(self);
+    VALUE_TO_ENUM(colorspace, new_cs, ColorspaceType);
+    (void) TransformImageColorspace(image, new_cs);
+
+    return self;
+#else
+    return Image_colorspace_eq(image, new_cs);
+#endif
+}
+
+
+/**
+ * Set the image's colorspace.
+ *
+ * Ruby usage:
+ *   - @verbatim Image#colorspace=Magick::ColorspaceType @endverbatim
+ *
+ * @param self this object
+ * @param colorspace the colorspace
+ * @return self
+ * @see Magick::colorSpace in Magick++'s Magick::colorSpace
+ */
+VALUE
 Image_colorspace_eq(VALUE self, VALUE colorspace)
 {
     Image *image;
@@ -2993,11 +3022,7 @@ Image_colorspace_eq(VALUE self, VALUE colorspace)
 
     image = rm_check_frozen(self);
     VALUE_TO_ENUM(colorspace, new_cs, ColorspaceType);
-#if defined(HAVE_TRANSFORMIMAGECOLORSPACE)
-    (void) TransformImageColorspace(image, new_cs);
-#else
     (void) SetImageColorspace(image, new_cs);
-#endif
 
     return self;
 }


### PR DESCRIPTION
rmagick is conflating SetImageColorspace and TransformImageColorspace. This is the difference between "convert foo.png -set colorspace rgb ..." and "convert foo.png -colorspace rgb ..."

The former is like a reinterpret-cast in C++: it doesn't change the data, it just says the data is in the given colorspace. The latter is a transform that changes the data based on the original image colorspace and the parameter.

I need SetImageColorspace and, in the current code, it's not available if TransformImageColorspace is available.

This is a partial patch. I didn't wire in or test image.transform_colorspace(colorspace). If you're interested, I can ...
