### PR TITLE
Add license into gemspec

### DIFF
--- a/rmagick.gemspec
+++ b/rmagick.gemspec
@@ -2,6 +2,7 @@ require 'date'
 Gem::Specification.new do |s|
   s.name = %q{rmagick}
   s.version = "2.13.2"
+  s.license = "MIT"
   s.date = Date.today.to_s
   s.summary = %q{Ruby binding to ImageMagick}
   s.description = %q{RMagick is an interface between Ruby and ImageMagick.}


### PR DESCRIPTION
So that tools like LicenseFinder can search license across gems better.

See https://github.com/rubygems/rubygems.org/issues/363 too
