### PR TITLE
Fix installation error on systems with HRDI enabled RMagick

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -152,14 +152,6 @@ if RUBY_PLATFORM !~ /mswin|mingw/
 
   $magick_version = `Magick-config --version`.chomp
 
-  # Ensure ImageMagick is not configured for HDRI
-  unless checking_for("HDRI disabled version of ImageMagick") do
-    not (`Magick-config --version`["HDRI"])
-  end
-    exit_failure "\nCan't install RMagick #{RMAGICK_VERS}."+
-           "\nRMagick does not work when ImageMagick is configured for High Dynamic Range Images."+
-           "\nDon't use the --enable-hdri option when configuring ImageMagick.\n"
-  end
 
   # Save flags
   $CFLAGS     = ENV["CFLAGS"].to_s   + " " + `Magick-config --cflags`.chomp

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -9819,7 +9819,7 @@ Image_pixel_color(int argc, VALUE *argv, VALUE self)
 #else
             IndexPacket *indexes = GetIndexes(image);
 #endif
-            old_color = image->colormap[*indexes];
+            old_color = image->colormap[(unsigned long)*indexes];
         }
         if (!image->matte)
         {


### PR DESCRIPTION
Integrates @bricef's fork, which in-turn implements a widely-available and widely-tested patch for HDRI enabled RMagick. 

Most linux package maintainers are moving toward HDRI support. The pull request makes RMagick usable on those systems. 

More details in #18 
