### PR TITLE
Fixed javascript link

### DIFF
--- a/doc/image1.html
+++ b/doc/image1.html
@@ -1203,25 +1203,25 @@ img = Image.read_inline(content)
       <table summary="compose_mask example">
         <tr>
           <td><a href=
-          "javascript:add_popup('compose_mask.rb.html')"><img src=
+          "javascript:popup('compose_mask.rb.html')"><img src=
           "ex/images/Flower_Hat.jpg" width="100" height="125" alt=
           "Source image for add_compose_mask example" title=
           "Click to see the example script" /></a></td>
 
           <td><a href=
-          "javascript:add_popup('compose_mask.rb.html')"><img src=
+          "javascript:popup('compose_mask.rb.html')"><img src=
           "ex/compose_mask_source.gif" width="100" height="125"
           alt="Background image for add_compose_mask example"
           title="Click to see the example script" /></a></td>
 
           <td><a href=
-          "javascript:add_popup('compose_mask.rb.html')"><img src=
+          "javascript:popup('compose_mask.rb.html')"><img src=
           "ex/compose_mask.gif" width="100" height="125" alt=
           "Mask image for compose_mask example" title=
           "Click to see the example script" /></a></td>
 
           <td><a href=
-          "javascript:add_popup('compose_mask.rb.html')"><img src=
+          "javascript:popup('compose_mask.rb.html')"><img src=
           "ex/compose_mask_example.jpg" width="93" height="125"
           alt="Result image for compose_mask example" title=
           "Click to see the example script" /></a></td>


### PR DESCRIPTION
I found that these incorrect links at https://rmagick.github.io/image1.html#add_compose_mask. I don't know what is the source for the documentation so I am sending at least this PR to point this out.

Please fix in the source for the documentation.

Thanks,
Jan
